### PR TITLE
tests for the transformation step

### DIFF
--- a/test/meta_schema/parser_test.clj
+++ b/test/meta_schema/parser_test.clj
@@ -1,6 +1,7 @@
-(ns meta-schema.core-test
+(ns meta-schema.parser-test
   (:require [clojure.test :refer :all]
             [meta-schema.core :as ms]
+            [spec-tools.core :as sc]
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [clojure.test.check.generators :as gen]
@@ -28,8 +29,6 @@
                     :spec-name gen/keyword-ns
                     :tk1 (gen/not-empty (gen/vector leaf-spec))
                     :tk2 leaf-spec))
-
-(gen/sample spec-file-gen 2)
 
 
 (s/def ::money (s/or :int int?
@@ -74,4 +73,4 @@
                 (ms/setup! (-> (io/resource "specs")
                                (io/file)
                                (file-seq)))
-                (= (spec-tools.core/spec? (ms/create-parser file-spec)))))
+                (= (sc/spec? (ms/create-parser file-spec)))))

--- a/test/meta_schema/reshape_data_test.clj
+++ b/test/meta_schema/reshape_data_test.clj
@@ -1,0 +1,41 @@
+(ns meta-schema.reshape-data-test
+  (:require  [clojure.test :refer [deftest is testing]]
+             [meta-schema.core :as ms]
+             [clojure.java.io :as io]))
+
+(deftest simple-reshape
+  (let [client-data {:zip ["101030-201", "987621-281"]
+                     :rent 980.322
+                     :university {:departments [{:zip {:address "University at Medium Inc.,"}}]}}
+
+        client-spec {:spec-name :my-project.client/payload
+                     :zip [{:spec :zipcode
+                            :destination :a}]
+                     :rent {:spec :money
+                            :destination :b}
+                     :university {:departments [{:zip {:address {:spec :zipcode
+                                                                 :destination :c}}}]}}]
+    (ms/setup! (-> (io/resource "specs") io/file file-seq))
+
+    (testing "Verify that a simple reshape of data input to output is valid."
+      (is (= {:my-new-zip ["101030-201", "987621-281"]
+              :my-new-rent 980.322
+              :my-new-address "University at Medium Inc.,"}
+             (ms/input-data->target-data client-data client-spec {:my-new-zip :a
+                                                                  :my-new-rent :b
+                                                                  :my-new-address :c}))))
+
+    (testing "A more complicated target structure"
+      (is (= {:my-company {:likes {:very {:nested {:structures ["101030-201", "987621-281"]
+                                                   :and {:I {:need 980.322
+                                                             :my {:job {:at "University at Medium Inc.,"}}}}}}}}}
+             (ms/input-data->target-data client-data client-spec
+                                         {:my-company {:likes {:very {:nested {:structures :a
+                                                                               :and {:I {:need :b
+                                                                                         :my {:job {:at :c}}}}}}}}}))))
+
+    (testing "Unfortunately, we have a edge case where the name of the FIELD in your target spec is the same as a DESTINATION keyword"
+      (is (not= {:b "University at Medium Inc.,"}
+                (ms/input-data->target-data client-data client-spec {:b :c}))
+          (= {980.322 "University at Medium Inc.,"}
+             (ms/input-data->target-data client-data client-spec {:b :c}))))))


### PR DESCRIPTION
Noticed that we don't have any test for the functionality of transforming the data from spec 1 to desired shape 2. It is also exemplified an edge case with the library at the moment, where you have to be aware of collision names between *destination* keywords and *target* shape keys.